### PR TITLE
PrefectureSelector 状態リフトアップ ＆ テスト更新

### DIFF
--- a/src/__tests__/components/PrefectureSelector.test.tsx
+++ b/src/__tests__/components/PrefectureSelector.test.tsx
@@ -14,31 +14,43 @@ describe('PrefectureSelector', () => {
         (getPrefectures as jest.Mock).mockResolvedValue(mockData);
     });
 
-    // テストの実行前にモックをリセット
+    // APIのモックをリセット
     it('都道府県一覧を取得して表示できる', async () => {
-        render(<PrefectureSelector />);
+        render(<PrefectureSelector selected={[]} onChange={() => {}} />);
 
-        // API呼び出しを待つ
         await waitFor(() => {
-            expect(screen.getByText('北海道')).toBeInTheDocument();
-            expect(screen.getByText('青森県')).toBeInTheDocument();
+            expect(screen.getByLabelText('北海道')).toBeInTheDocument();
+            expect(screen.getByLabelText('青森県')).toBeInTheDocument();
         });
     });
 
-    // チェックボックスの初期状態を確認
-    it('チェックボックスをクリックすると選択状態が更新される', async () => {
-        render(<PrefectureSelector />);
+    // APIのモックが失敗した場合のテスト
+    it('チェック状態が props.selected に応じて反映される', async () => {
+        render(<PrefectureSelector selected={[1]} onChange={() => {}} />);
 
-        // チェックボックスの取得
-        const checkbox = await screen.findByLabelText('北海道'); // <label>から取得
+        const checkbox = await screen.findByLabelText('北海道');
+        expect((checkbox as HTMLInputElement).checked).toBe(true);
+    });
 
-        // 初期はunchecked
-        expect((checkbox as HTMLInputElement).checked).toBe(false);
+    // チェックボックスの状態が props.selected に応じて反映されるか
+    it('チェック時に onChange が呼び出される', async () => {
+        const mockOnChange = jest.fn();
+        render(<PrefectureSelector selected={[]} onChange={mockOnChange} />);
 
-        // チェックする
+        const checkbox = await screen.findByLabelText('北海道');
         fireEvent.click(checkbox);
 
-        // チェック済みになる
-        expect((checkbox as HTMLInputElement).checked).toBe(true);
+        expect(mockOnChange).toHaveBeenCalledWith([1]);
+    });
+
+    // チェックボックスの状態が props.selected に応じて反映されるか
+    it('チェック解除時に onChange が呼び出される', async () => {
+        const mockOnChange = jest.fn();
+        render(<PrefectureSelector selected={[1]} onChange={mockOnChange} />);
+
+        const checkbox = await screen.findByLabelText('北海道');
+        fireEvent.click(checkbox);
+
+        expect(mockOnChange).toHaveBeenCalledWith([]); // チェック外したとき
     });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
 import AppLayout from '@/components/layout/AppLayout';
-import PrefectureSelector from '@/components/prefecture/PrefectureSelector';
+
 export default function Home() {
-    return (
-        <AppLayout>
-            <PrefectureSelector />
-        </AppLayout>
-    );
+    return <AppLayout />;
 }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,17 +1,21 @@
-import { ReactNode } from 'react';
+'use client';
+
+import { useState } from 'react';
+import PrefectureSelector from '../prefecture/PrefectureSelector';
 import styles from '@styles/components/AppLayout.module.scss';
 
-type Props = {
-    children?: ReactNode;
-};
+export default function AppLayout() {
+    const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
 
-export default function AppLayout({ children }: Props) {
     return (
         <div className={styles.wrapper}>
             <header className={styles.header}>
                 <h1>都道府県別・人口構成グラフ</h1>
             </header>
-            <main className={styles.main}>{children}</main>
+            <main className={styles.main}>
+                <PrefectureSelector selected={selectedPrefectures} onChange={setSelectedPrefectures} />
+                {/* 🔜 今後ここにチャートを追加予定 */}
+            </main>
         </div>
     );
 }

--- a/src/components/prefecture/PrefectureSelector.tsx
+++ b/src/components/prefecture/PrefectureSelector.tsx
@@ -6,9 +6,13 @@ import { getPrefectures } from '@/apis/getPrefectures';
 import PrefectureCheckbox from './PrefectureCheckbox';
 import styles from '@styles/components/PrefectureSelector.module.scss';
 
-export default function PrefectureSelector() {
+type Props = {
+    selected: number[];
+    onChange: (selected: number[]) => void;
+};
+
+export default function PrefectureSelector({ selected, onChange }: Props) {
     const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
-    const [selected, setSelected] = useState<number[]>([]);
 
     useEffect(() => {
         const fetchPref = async () => {
@@ -24,7 +28,7 @@ export default function PrefectureSelector() {
     }, []);
 
     const handleChange = (prefCode: number, checked: boolean) => {
-        setSelected((prev) => (checked ? [...prev, prefCode] : prev.filter((code) => code !== prefCode)));
+        onChange(checked ? [...selected, prefCode] : selected.filter((code) => code !== prefCode));
     };
 
     return (


### PR DESCRIPTION
#  PrefectureSelector 状態リフトアップ ＆ テスト更新

##  変更内容
都道府県の選択状態を管理する state（selectedPrefectures）を PrefectureSelector コンポーネントから AppLayout にリフトアップし、より柔軟な状態管理ができるように改善しました。
それに伴い、テストコードも新しい props ベースの仕様に対応させました。

###  主な変更点
- selectedPrefectures の state を AppLayout に移動
- PrefectureSelector を controlled component に変更し、selected / onChange を props として受け取るように修正
- チェック状態と選択ロジックは上位コンポーネントで管理
- テストコードをリファクタ後の仕様に対応し、ユニットテストを再構成
