### PR TITLE
Loading`コンポーネントに対してユニットテストを追加しました。

### DIFF
--- a/src/__tests__/components/Loading.test.tsx
+++ b/src/__tests__/components/Loading.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Loading from '@/components/common/Loading';
+
+describe('Loading', () => {
+    it('「読み込み中...」のテキストが表示されること', () => {
+        render(<Loading />);
+        expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    });
+
+    it('スピナーの要素が存在すること', () => {
+        render(<Loading />);
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    });
+});

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -3,7 +3,7 @@ import styles from '@styles/components/Loading.module.scss';
 export default function Loading() {
     return (
         <div className={styles.wrapper} data-testid="loading">
-            <div className={styles.spinner} />
+            <div className={styles.spinner} data-testid="spinner" />
             <p className={styles.text}>読み込み中...</p>
         </div>
     );


### PR DESCRIPTION
# Loading`コンポーネントに対してユニットテストを追加しました。

## 変更内容

- Loading.test.tsxを新規作成し、テキストとスピナーの存在を検証
- data-testid="loading" を wrapper div に追加してテストしやすく
- コンポーネントの表示確認に必要な最小限のテストをカバー