### PR TITLE
feat: 都道府県別・人口構成グラフアプリの実装を完了

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.1.0",
             "dependencies": {
                 "axios": "^1.8.4",
+                "highcharts": "^12.1.2",
+                "highcharts-react-official": "^3.2.1",
                 "next": "15.2.4",
                 "normalize.css": "^8.0.1",
                 "react": "^19.0.0",
@@ -5826,6 +5828,22 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/highcharts": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.1.2.tgz",
+            "integrity": "sha512-paZ72q1um0zZT1sS+O/3JfXVSOLPmZ0zlo8SgRc0rEplPFPQUPc4VpkgQS8IUTueeOBgIWwVpAWyC9tBYbQ0kg==",
+            "license": "https://www.highcharts.com/license"
+        },
+        "node_modules/highcharts-react-official": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.2.1.tgz",
+            "integrity": "sha512-hyQTX7ezCxl7JqumaWiGsroGWalzh24GedQIgO3vJbkGOZ6ySRAltIYjfxhrq4HszJOySZegotEF7v+haQ75UA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "highcharts": ">=6.0.0",
+                "react": ">=16.8.0"
             }
         },
         "node_modules/html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "type": "module",
     "dependencies": {
         "axios": "^1.8.4",
+        "highcharts": "^12.1.2",
+        "highcharts-react-official": "^3.2.1",
         "next": "15.2.4",
         "normalize.css": "^8.0.1",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "check-types": "tsc --noEmit",
         "test": "jest",
         "test:watch": "jest --watch",
+        "test:coverage": "jest --coverage",
         "check-all": "npm run format && npm run check-types && npm run lint && npm run test"
     },
     "type": "module",

--- a/src/__tests__/apis/getPopulation.test.ts
+++ b/src/__tests__/apis/getPopulation.test.ts
@@ -1,0 +1,71 @@
+import { getPopulation } from '@/apis/getPopulation';
+import { apiClient } from '@/libs/apiClient';
+import { GetPopulationResponse } from '@/apis/types';
+
+jest.mock('@/libs/apiClient');
+
+describe('getPopulation (with cache)', () => {
+    const mockResponse: GetPopulationResponse = {
+        message: null,
+        result: {
+            boundaryYear: 2020,
+            data: [
+                {
+                    label: '総人口',
+                    data: [
+                        { year: 1960, value: 100000 },
+                        { year: 1970, value: 120000 },
+                    ],
+                },
+            ],
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // テストケースの実行前にキャッシュをクリア
+    it('APIからデータを取得してキャッシュする', async () => {
+        (apiClient.get as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+
+        const result = await getPopulation(1);
+
+        expect(apiClient.get).toHaveBeenCalledTimes(1);
+        expect(apiClient.get).toHaveBeenCalledWith('/population/composition/perYear?prefCode=1');
+        expect(result).toEqual(mockResponse);
+    });
+
+    // キャッシュが存在する場合はAPIを呼ばずにキャッシュから取得
+    it('同じprefCodeで再度呼び出した場合、APIを呼ばずにキャッシュから取得する', async () => {
+        // キャッシュされている前提で、APIを呼び出さないようにする
+        const result = await getPopulation(1);
+
+        expect(apiClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual(mockResponse);
+    });
+
+    // キャッシュが存在しない場合はAPIを呼び出す
+    it('別のprefCodeで呼び出した場合は新たにAPIを呼び出す', async () => {
+        const newResponse: GetPopulationResponse = {
+            message: null,
+            result: {
+                boundaryYear: 2020,
+                data: [
+                    {
+                        label: '総人口',
+                        data: [{ year: 1960, value: 99999 }],
+                    },
+                ],
+            },
+        };
+
+        (apiClient.get as jest.Mock).mockResolvedValueOnce({ data: newResponse });
+
+        const result = await getPopulation(2);
+
+        expect(apiClient.get).toHaveBeenCalledTimes(1);
+        expect(apiClient.get).toHaveBeenCalledWith('/population/composition/perYear?prefCode=2');
+        expect(result).toEqual(newResponse);
+    });
+});

--- a/src/__tests__/components/Loading.test.tsx
+++ b/src/__tests__/components/Loading.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Loading from '@/components/common/Loading';
+
+describe('Loading', () => {
+    it('「読み込み中...」のテキストが表示されること', () => {
+        render(<Loading />);
+        expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    });
+
+    it('スピナーの要素が存在すること', () => {
+        render(<Loading />);
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    });
+});

--- a/src/__tests__/components/PopulationChart.test.tsx
+++ b/src/__tests__/components/PopulationChart.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import PopulationChart from '@/components/chart/PopulationChart';
+import { PopulationDataPoint } from '@/apis/types';
+
+describe('PopulationChart', () => {
+    const dataMap = new Map<number, PopulationDataPoint[]>([
+        [
+            1,
+            [
+                { year: 1960, value: 100000 },
+                { year: 1970, value: 120000 },
+            ],
+        ],
+        [
+            2,
+            [
+                { year: 1960, value: 90000 },
+                { year: 1970, value: 110000 },
+            ],
+        ],
+    ]);
+
+    const prefNames = new Map<number, string>([
+        [1, '北海道'],
+        [2, '青森県'],
+    ]);
+
+    // テストケースを追加
+    it('タイトルが表示されること', () => {
+        render(<PopulationChart dataMap={dataMap} prefNames={prefNames} label="総人口" />);
+        expect(screen.getByText('総人口の推移')).toBeInTheDocument();
+    });
+
+    // 凡例が表示されること
+    it('都道府県名が凡例に表示されること', () => {
+        render(<PopulationChart dataMap={dataMap} prefNames={prefNames} label="総人口" />);
+        expect(screen.getByText('北海道')).toBeInTheDocument();
+        expect(screen.getByText('青森県')).toBeInTheDocument();
+    });
+
+    // グラフが表示されること
+    it('年度がX軸に表示される（カテゴリが含まれていること）', () => {
+        render(<PopulationChart dataMap={dataMap} prefNames={prefNames} label="総人口" />);
+        expect(screen.getByText('1960')).toBeInTheDocument();
+        expect(screen.getByText('1970')).toBeInTheDocument();
+    });
+});

--- a/src/__tests__/components/PrefectureSelector.test.tsx
+++ b/src/__tests__/components/PrefectureSelector.test.tsx
@@ -26,7 +26,8 @@ describe('PrefectureSelector', () => {
 
     // APIのモックが失敗した場合のテスト
     it('チェック状態が props.selected に応じて反映される', async () => {
-        render(<PrefectureSelector selected={[1]} onChange={() => {}} />);
+        const selectedPrefecture = mockData[0]; // 北海道
+        render(<PrefectureSelector selected={[selectedPrefecture]} onChange={() => {}} />);
 
         const checkbox = await screen.findByLabelText('北海道');
         expect((checkbox as HTMLInputElement).checked).toBe(true);
@@ -40,17 +41,18 @@ describe('PrefectureSelector', () => {
         const checkbox = await screen.findByLabelText('北海道');
         fireEvent.click(checkbox);
 
-        expect(mockOnChange).toHaveBeenCalledWith([1]);
+        expect(mockOnChange).toHaveBeenCalledWith([mockData[0]]); // 北海道のオブジェクト全体
     });
 
     // チェックボックスの状態が props.selected に応じて反映されるか
     it('チェック解除時に onChange が呼び出される', async () => {
         const mockOnChange = jest.fn();
-        render(<PrefectureSelector selected={[1]} onChange={mockOnChange} />);
+        const selectedPrefecture = mockData[0]; // 北海道
+        render(<PrefectureSelector selected={[selectedPrefecture]} onChange={mockOnChange} />);
 
         const checkbox = await screen.findByLabelText('北海道');
         fireEvent.click(checkbox);
 
-        expect(mockOnChange).toHaveBeenCalledWith([]); // チェック外したとき
+        expect(mockOnChange).toHaveBeenCalledWith([]); // 空配列
     });
 });

--- a/src/__tests__/components/PrefectureSelector.test.tsx
+++ b/src/__tests__/components/PrefectureSelector.test.tsx
@@ -1,58 +1,62 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import PrefectureSelector from '@/components/prefecture/PrefectureSelector';
-import { getPrefectures } from '@/apis/getPrefectures';
+import { Prefecture } from '@/apis/types';
 
-jest.mock('@/apis/getPrefectures');
+jest.mock('@/hooks/usePrefectures', () => ({
+    usePrefectures: () => ({
+        prefectures: [
+            { prefCode: 1, prefName: '北海道' },
+            { prefCode: 2, prefName: '青森県' },
+        ],
+        loading: false,
+        error: null,
+    }),
+}));
 
 describe('PrefectureSelector', () => {
-    const mockData = [
+    const mockData: Prefecture[] = [
         { prefCode: 1, prefName: '北海道' },
         { prefCode: 2, prefName: '青森県' },
     ];
 
-    beforeEach(() => {
-        (getPrefectures as jest.Mock).mockResolvedValue(mockData);
+    // チェックボックスの初期状態が正しく設定されること
+    it('props.selected に応じてチェックが反映される', () => {
+        render(<PrefectureSelector selected={[mockData[0]]} onChange={() => {}} />);
+
+        const checkbox = screen.getByLabelText('北海道') as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
     });
 
-    // APIのモックをリセット
-    it('都道府県一覧を取得して表示できる', async () => {
-        render(<PrefectureSelector selected={[]} onChange={() => {}} />);
-
-        await waitFor(() => {
-            expect(screen.getByLabelText('北海道')).toBeInTheDocument();
-            expect(screen.getByLabelText('青森県')).toBeInTheDocument();
-        });
-    });
-
-    // APIのモックが失敗した場合のテスト
-    it('チェック状態が props.selected に応じて反映される', async () => {
-        const selectedPrefecture = mockData[0]; // 北海道
-        render(<PrefectureSelector selected={[selectedPrefecture]} onChange={() => {}} />);
-
-        const checkbox = await screen.findByLabelText('北海道');
-        expect((checkbox as HTMLInputElement).checked).toBe(true);
-    });
-
-    // チェックボックスの状態が props.selected に応じて反映されるか
-    it('チェック時に onChange が呼び出される', async () => {
+    // チェックボックスをクリックした際にonChangeが呼ばれること
+    it('チェック時に onChange が呼ばれる', () => {
         const mockOnChange = jest.fn();
         render(<PrefectureSelector selected={[]} onChange={mockOnChange} />);
 
-        const checkbox = await screen.findByLabelText('北海道');
+        const checkbox = screen.getByLabelText('北海道');
         fireEvent.click(checkbox);
 
-        expect(mockOnChange).toHaveBeenCalledWith([mockData[0]]); // 北海道のオブジェクト全体
+        expect(mockOnChange).toHaveBeenCalledWith([mockData[0]]);
     });
 
-    // チェックボックスの状態が props.selected に応じて反映されるか
-    it('チェック解除時に onChange が呼び出される', async () => {
+    // チェックを外した際にonChangeが呼ばれること
+    it('チェック解除時に onChange が呼ばれる', () => {
         const mockOnChange = jest.fn();
-        const selectedPrefecture = mockData[0]; // 北海道
-        render(<PrefectureSelector selected={[selectedPrefecture]} onChange={mockOnChange} />);
+        render(<PrefectureSelector selected={[mockData[0]]} onChange={mockOnChange} />);
 
-        const checkbox = await screen.findByLabelText('北海道');
+        const checkbox = screen.getByLabelText('北海道');
         fireEvent.click(checkbox);
 
-        expect(mockOnChange).toHaveBeenCalledWith([]); // 空配列
+        expect(mockOnChange).toHaveBeenCalledWith([]);
+    });
+
+    // 全選択解除ボタンをクリックした際にonChangeが呼ばれること
+    it('全ての選択を解除ボタンで onChange([]) が呼ばれる', () => {
+        const mockOnChange = jest.fn();
+        render(<PrefectureSelector selected={[{ prefCode: 1, prefName: '北海道' }]} onChange={mockOnChange} />);
+
+        const button = screen.getByTestId('unselect-all-button');
+        fireEvent.click(button);
+
+        expect(mockOnChange).toHaveBeenCalledWith([]);
     });
 });

--- a/src/__tests__/hook/usePopulationData.test.ts
+++ b/src/__tests__/hook/usePopulationData.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePopulationData } from '@/hooks/usePopulationData';
+import { getPopulation } from '@/apis/getPopulation';
+import { Prefecture, GetPopulationResponse } from '@/apis/types';
+
+jest.mock('@/apis/getPopulation');
+
+const mockPrefectures: Prefecture[] = [
+    { prefCode: 1, prefName: '北海道' },
+    { prefCode: 2, prefName: '青森県' },
+];
+
+const mockResponse1: GetPopulationResponse = {
+    message: null,
+    result: {
+        boundaryYear: 2020,
+        data: [
+            {
+                label: '総人口',
+                data: [
+                    { year: 1960, value: 100000 },
+                    { year: 1970, value: 120000 },
+                ],
+            },
+            {
+                label: '年少人口',
+                data: [
+                    { year: 1960, value: 20000 },
+                    { year: 1970, value: 25000 },
+                ],
+            },
+        ],
+    },
+};
+
+const mockResponse2: GetPopulationResponse = {
+    message: null,
+    result: {
+        boundaryYear: 2020,
+        data: [
+            {
+                label: '総人口',
+                data: [
+                    { year: 1960, value: 90000 },
+                    { year: 1970, value: 110000 },
+                ],
+            },
+            {
+                label: '年少人口',
+                data: [
+                    { year: 1960, value: 18000 },
+                    { year: 1970, value: 22000 },
+                ],
+            },
+        ],
+    },
+};
+
+describe('usePopulationData', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // APIのモックをリセット
+    it('初期状態で総人口データを取得し、prefCodeごとのMapを構築する', async () => {
+        (getPopulation as jest.Mock).mockImplementation((prefCode: number) => {
+            return prefCode === 1 ? Promise.resolve(mockResponse1) : Promise.resolve(mockResponse2);
+        });
+
+        const { result } = renderHook(() => usePopulationData(mockPrefectures));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.error).toBeNull();
+        expect(result.current.chartDataMap.size).toBe(2);
+        expect(result.current.chartDataMap.get(1)).toEqual(mockResponse1.result.data[0].data);
+        expect(result.current.prefNamesMap.get(1)).toBe('北海道');
+    });
+
+    // APIのモックが失敗した場合のテスト
+    it('人口ラベルを変更するとデータが更新される', async () => {
+        (getPopulation as jest.Mock).mockResolvedValue(mockResponse1);
+
+        const { result } = renderHook(() => usePopulationData([mockPrefectures[0]]));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        act(() => {
+            result.current.setSelectedLabel('年少人口');
+        });
+
+        await waitFor(() => {
+            expect(result.current.chartDataMap.get(1)).toEqual(mockResponse1.result.data[1].data);
+        });
+    });
+
+    // チェックボックスの状態が props.selected に応じて反映されるか
+    it('APIエラー時にerrorが設定される', async () => {
+        (getPopulation as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+        const { result } = renderHook(() => usePopulationData([mockPrefectures[0]]));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.error).toBe('データ取得に失敗しました');
+        expect(result.current.chartDataMap.size).toBe(0);
+    });
+});

--- a/src/__tests__/hook/usePrefectures.test.ts
+++ b/src/__tests__/hook/usePrefectures.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePrefectures } from '@/hooks/usePrefectures';
+import { getPrefectures } from '@/apis/getPrefectures';
+import { Prefecture } from '@/apis/types';
+
+jest.mock('@/apis/getPrefectures');
+
+const mockData: Prefecture[] = [
+    { prefCode: 1, prefName: '北海道' },
+    { prefCode: 2, prefName: '青森県' },
+];
+
+describe('usePrefectures', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // キャッシュが存在する場合のテスト
+    it('都道府県データを取得し、状態に反映される', async () => {
+        (getPrefectures as jest.Mock).mockResolvedValue(mockData);
+
+        const { result } = renderHook(() => usePrefectures());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.prefectures).toEqual(mockData);
+        expect(result.current.error).toBeNull();
+    });
+
+    // キャッシュが存在しない場合のテスト
+    it('APIエラー時にエラーステートが設定される', async () => {
+        (getPrefectures as jest.Mock).mockRejectedValue(new Error('Network Error'));
+
+        const { result } = renderHook(() => usePrefectures());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.error).toBe('データ取得に失敗しました');
+        expect(result.current.prefectures).toEqual([]);
+    });
+});

--- a/src/apis/getPopulation.ts
+++ b/src/apis/getPopulation.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/libs/apiClient';
+import { GetPopulationResponse } from './types';
+
+// 都道府県ごとの人口データをキャッシュするMap
+const populationCache = new Map<number, GetPopulationResponse>();
+
+// 人口構成データを取得する（prefCode単位でキャッシュあり）
+export const getPopulation = async (prefCode: number): Promise<GetPopulationResponse> => {
+    // キャッシュが存在する場合はそれを返す
+    if (populationCache.has(prefCode)) {
+        return populationCache.get(prefCode)!;
+    }
+
+    // APIから取得してキャッシュに保存
+    const { data } = await apiClient.get<GetPopulationResponse>(`/population/composition/perYear?prefCode=${prefCode}`);
+
+    populationCache.set(prefCode, data);
+    return data;
+};

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -7,3 +7,21 @@ export type GetPrefecturesResponse = {
     message: null;
     result: Prefecture[];
 };
+
+export type PopulationDataPoint = {
+    year: number;
+    value: number;
+};
+
+export type PopulationComposition = {
+    label: '総人口' | '年少人口' | '生産年齢人口' | '老年人口';
+    data: PopulationDataPoint[];
+};
+
+export type GetPopulationResponse = {
+    message: string | null;
+    result: {
+        boundaryYear: number;
+        data: PopulationComposition[];
+    };
+};

--- a/src/components/chart/PopulationChart.tsx
+++ b/src/components/chart/PopulationChart.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { PopulationDataPoint } from '@/apis/types';
+import styles from '@styles/components/PopulationChart.module.scss';
+
+type Props = {
+    dataMap: Map<number, PopulationDataPoint[]>;
+    prefNames: Map<number, string>;
+    label: string;
+};
+
+export default function PopulationChart({ dataMap, prefNames, label }: Props) {
+    const colors = ['#00A0E9', '#E60012', '#009944', '#8957e5', '#f9a8d4', '#84cc16', '#7c3aed'];
+
+    const series = Array.from(dataMap.entries()).map(([prefCode, data], index) => ({
+        type: 'line' as const,
+        name: prefNames.get(prefCode) || `県コード: ${prefCode}`,
+        data: data.map((point) => ({
+            x: point.year,
+            y: point.value,
+        })),
+        color: colors[index % colors.length],
+    }));
+    const options: Highcharts.Options = {
+        title: {
+            text: `${label}の推移`,
+            style: {
+                fontSize: '16px',
+            },
+        },
+        credits: {
+            enabled: false,
+        },
+        xAxis: {
+            title: {
+                text: '年度',
+            },
+            categories: dataMap.size > 0 ? Array.from(dataMap.values())[0].map((point) => point.year.toString()) : [],
+        },
+        yAxis: {
+            title: {
+                text: '人口数',
+            },
+            labels: {
+                formatter: function () {
+                    return Highcharts.numberFormat(Number(this.value), 0, '', ',');
+                },
+            },
+        },
+        series,
+        tooltip: {
+            formatter: function () {
+                return `${this.x}年<br/>${this.series.name}: <b>${Highcharts.numberFormat(Number(this.y), 0, '', ',')}人</b>`;
+            },
+        },
+        plotOptions: {
+            series: {
+                animation: {
+                    duration: 500,
+                },
+                marker: {
+                    enabled: true,
+                },
+            },
+        },
+        legend: {
+            align: 'center',
+            verticalAlign: 'bottom',
+            layout: 'horizontal',
+            itemMarginTop: 5,
+            itemMarginBottom: 5,
+        },
+    };
+
+    return (
+        <div className={styles.chart}>
+            <HighchartsReact highcharts={Highcharts} options={options} />
+        </div>
+    );
+}

--- a/src/components/chart/PopulationChart.tsx
+++ b/src/components/chart/PopulationChart.tsx
@@ -2,8 +2,8 @@
 
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
-import { PopulationDataPoint } from '@/apis/types';
 import styles from '@styles/components/PopulationChart.module.scss';
+import { PopulationDataPoint } from '@/apis/types';
 
 type Props = {
     dataMap: Map<number, PopulationDataPoint[]>;
@@ -12,8 +12,10 @@ type Props = {
 };
 
 export default function PopulationChart({ dataMap, prefNames, label }: Props) {
+    // カラーは固定の配列で循環
     const colors = ['#00A0E9', '#E60012', '#009944', '#8957e5', '#f9a8d4', '#84cc16', '#7c3aed'];
 
+    // Highchartsのseriesを生成
     const series = Array.from(dataMap.entries()).map(([prefCode, data], index) => ({
         type: 'line' as const,
         name: prefNames.get(prefCode) || `県コード: ${prefCode}`,
@@ -23,26 +25,21 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
         })),
         color: colors[index % colors.length],
     }));
+
+    // Highchartsのオプション
     const options: Highcharts.Options = {
         title: {
             text: `${label}の推移`,
-            style: {
-                fontSize: '16px',
-            },
         },
         credits: {
             enabled: false,
         },
         xAxis: {
-            title: {
-                text: '年度',
-            },
+            title: { text: '年度' },
             categories: dataMap.size > 0 ? Array.from(dataMap.values())[0].map((point) => point.year.toString()) : [],
         },
         yAxis: {
-            title: {
-                text: '人口数',
-            },
+            title: { text: '人口数' },
             labels: {
                 formatter: function () {
                     return Highcharts.numberFormat(Number(this.value), 0, '', ',');
@@ -52,17 +49,18 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
         series,
         tooltip: {
             formatter: function () {
-                return `${this.x}年<br/>${this.series.name}: <b>${Highcharts.numberFormat(Number(this.y), 0, '', ',')}人</b>`;
+                return `${this.x}年<br/>${this.series.name}: <b>${Highcharts.numberFormat(
+                    Number(this.y),
+                    0,
+                    '',
+                    ',',
+                )}人</b>`;
             },
         },
         plotOptions: {
             series: {
-                animation: {
-                    duration: 500,
-                },
-                marker: {
-                    enabled: true,
-                },
+                animation: { duration: 500 },
+                marker: { enabled: true },
             },
         },
         legend: {
@@ -71,6 +69,9 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
             layout: 'horizontal',
             itemMarginTop: 5,
             itemMarginBottom: 5,
+        },
+        accessibility: {
+            enabled: false,
         },
     };
 

--- a/src/components/chart/PopulationChart.tsx
+++ b/src/components/chart/PopulationChart.tsx
@@ -30,6 +30,9 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
     const options: Highcharts.Options = {
         title: {
             text: `${label}の推移`,
+            style: {
+                fontSize: '16px',
+            },
         },
         credits: {
             enabled: false,
@@ -37,12 +40,20 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
         xAxis: {
             title: { text: '年度' },
             categories: dataMap.size > 0 ? Array.from(dataMap.values())[0].map((point) => point.year.toString()) : [],
+            labels: {
+                style: {
+                    fontSize: '14px',
+                },
+            },
         },
         yAxis: {
             title: { text: '人口数' },
             labels: {
                 formatter: function () {
                     return Highcharts.numberFormat(Number(this.value), 0, '', ',');
+                },
+                style: {
+                    fontSize: '14px',
                 },
             },
         },
@@ -55,6 +66,9 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
                     '',
                     ',',
                 )}人</b>`;
+            },
+            style: {
+                fontSize: '14px',
             },
         },
         plotOptions: {
@@ -69,9 +83,52 @@ export default function PopulationChart({ dataMap, prefNames, label }: Props) {
             layout: 'horizontal',
             itemMarginTop: 5,
             itemMarginBottom: 5,
+            itemStyle: {
+                fontSize: '14px',
+            },
         },
         accessibility: {
             enabled: false,
+        },
+        responsive: {
+            rules: [
+                {
+                    condition: {
+                        maxWidth: 768,
+                    },
+                    chartOptions: {
+                        title: {
+                            style: {
+                                fontSize: '13px',
+                            },
+                        },
+                        xAxis: {
+                            labels: {
+                                style: {
+                                    fontSize: '11px',
+                                },
+                            },
+                        },
+                        yAxis: {
+                            labels: {
+                                style: {
+                                    fontSize: '11px',
+                                },
+                            },
+                        },
+                        legend: {
+                            itemStyle: {
+                                fontSize: '11px',
+                            },
+                        },
+                        tooltip: {
+                            style: {
+                                fontSize: '11px',
+                            },
+                        },
+                    },
+                },
+            ],
         },
     };
 

--- a/src/components/chart/PopulationChartContainer.tsx
+++ b/src/components/chart/PopulationChartContainer.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getPopulation } from '@/apis/getPopulation';
+import PopulationChart from './PopulationChart';
+import { PopulationDataPoint, PopulationComposition, Prefecture } from '@/apis/types';
+import styles from '@styles/components/PopulationChartContainer.module.scss';
+
+// 人口の種類リスト（単一選択）
+const populationLabels: PopulationComposition['label'][] = ['総人口', '年少人口', '生産年齢人口', '老年人口'];
+
+type Props = {
+    prefectures: Prefecture[];
+};
+
+export default function PopulationChartContainer({ prefectures }: Props) {
+    const [selectedLabel, setSelectedLabel] = useState<PopulationComposition['label']>('総人口');
+    const [chartDataMap, setChartDataMap] = useState<Map<number, PopulationDataPoint[]>>(new Map());
+    const [prefNamesMap, setPrefNamesMap] = useState<Map<number, string>>(new Map());
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const promises = prefectures.map(async (prefecture) => {
+                    const result = await getPopulation(prefecture.prefCode);
+                    const composition = result.result.data.find(
+                        (comp: PopulationComposition) => comp.label === selectedLabel,
+                    );
+                    return {
+                        prefCode: prefecture.prefCode,
+                        prefName: prefecture.prefName,
+                        data: composition?.data || [],
+                    };
+                });
+
+                const results = await Promise.all(promises);
+                const newDataMap = new Map();
+                const newPrefNamesMap = new Map();
+
+                results.forEach(({ prefCode, prefName, data }) => {
+                    newDataMap.set(prefCode, data);
+                    newPrefNamesMap.set(prefCode, prefName);
+                });
+
+                setChartDataMap(newDataMap);
+                setPrefNamesMap(newPrefNamesMap);
+            } catch (err) {
+                console.error(err);
+                setError('データ取得に失敗しました');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [prefectures, selectedLabel]);
+    return (
+        <div className={styles.container}>
+            <div className={styles.buttonGroup}>
+                {populationLabels.map((label) => (
+                    <button
+                        key={label}
+                        onClick={() => setSelectedLabel(label)}
+                        className={`${styles.button} ${label === selectedLabel ? styles.active : ''}`}
+                    >
+                        {label}
+                    </button>
+                ))}
+            </div>
+
+            {loading && <p className={styles.message}>読み込み中...</p>}
+            {error && <p className={styles.error}>{error}</p>}
+
+            {!loading && !error && (
+                <PopulationChart dataMap={chartDataMap} prefNames={prefNamesMap} label={selectedLabel} />
+            )}
+        </div>
+    );
+}

--- a/src/components/chart/PopulationChartContainer.tsx
+++ b/src/components/chart/PopulationChartContainer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { getPopulation } from '@/apis/getPopulation';
-import PopulationChart from './PopulationChart';
-import { PopulationDataPoint, PopulationComposition, Prefecture } from '@/apis/types';
 import styles from '@styles/components/PopulationChartContainer.module.scss';
+import { usePopulationData } from '@/hooks/usePopulationData';
+import { PopulationComposition, Prefecture } from '@/apis/types';
+import PopulationChart from './PopulationChart';
+import Loading from '../common/Loading';
 
 // 人口の種類リスト（単一選択）
 const populationLabels: PopulationComposition['label'][] = ['総人口', '年少人口', '生産年齢人口', '老年人口'];
@@ -14,50 +14,10 @@ type Props = {
 };
 
 export default function PopulationChartContainer({ prefectures }: Props) {
-    const [selectedLabel, setSelectedLabel] = useState<PopulationComposition['label']>('総人口');
-    const [chartDataMap, setChartDataMap] = useState<Map<number, PopulationDataPoint[]>>(new Map());
-    const [prefNamesMap, setPrefNamesMap] = useState<Map<number, string>>(new Map());
-    const [loading, setLoading] = useState<boolean>(false);
-    const [error, setError] = useState<string | null>(null);
+    // カスタムフックから状態と関数を取得
+    const { selectedLabel, setSelectedLabel, chartDataMap, prefNamesMap, loading, error } =
+        usePopulationData(prefectures);
 
-    useEffect(() => {
-        const fetchData = async () => {
-            setLoading(true);
-            setError(null);
-            try {
-                const promises = prefectures.map(async (prefecture) => {
-                    const result = await getPopulation(prefecture.prefCode);
-                    const composition = result.result.data.find(
-                        (comp: PopulationComposition) => comp.label === selectedLabel,
-                    );
-                    return {
-                        prefCode: prefecture.prefCode,
-                        prefName: prefecture.prefName,
-                        data: composition?.data || [],
-                    };
-                });
-
-                const results = await Promise.all(promises);
-                const newDataMap = new Map();
-                const newPrefNamesMap = new Map();
-
-                results.forEach(({ prefCode, prefName, data }) => {
-                    newDataMap.set(prefCode, data);
-                    newPrefNamesMap.set(prefCode, prefName);
-                });
-
-                setChartDataMap(newDataMap);
-                setPrefNamesMap(newPrefNamesMap);
-            } catch (err) {
-                console.error(err);
-                setError('データ取得に失敗しました');
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchData();
-    }, [prefectures, selectedLabel]);
     return (
         <div className={styles.container}>
             <div className={styles.buttonGroup}>
@@ -72,7 +32,7 @@ export default function PopulationChartContainer({ prefectures }: Props) {
                 ))}
             </div>
 
-            {loading && <p className={styles.message}>読み込み中...</p>}
+            {loading && <Loading />}
             {error && <p className={styles.error}>{error}</p>}
 
             {!loading && !error && (

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -3,7 +3,7 @@ import styles from '@styles/components/Loading.module.scss';
 export default function Loading() {
     return (
         <div className={styles.wrapper} data-testid="loading">
-            <div className={styles.spinner} />
+            <div className={styles.spinner} data-testid="spinner" />
             <p className={styles.text}>読み込み中...</p>
         </div>
     );

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,0 +1,10 @@
+import styles from '@styles/components/Loading.module.scss';
+
+export default function Loading() {
+    return (
+        <div className={styles.wrapper} data-testid="loading">
+            <div className={styles.spinner} />
+            <p className={styles.text}>読み込み中...</p>
+        </div>
+    );
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,13 +1,23 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Prefecture } from '@/apis/types';
 import PrefectureSelector from '@/components/prefecture/PrefectureSelector';
 import PopulationChartContainer from '@/components/chart/PopulationChartContainer';
+import { usePrefectures } from '@/hooks/usePrefectures';
 import styles from '@styles/components/AppLayout.module.scss';
 
 export default function AppLayout() {
+    const { prefectures, loading } = usePrefectures();
     const [selectedPrefectures, setSelectedPrefectures] = useState<Prefecture[]>([]);
+
+    // 初期選択：東京 (13) と大阪 (27)
+    useEffect(() => {
+        if (!loading && prefectures.length > 0 && selectedPrefectures.length === 0) {
+            const defaultPrefectures = prefectures.filter((p) => p.prefCode === 13 || p.prefCode === 27);
+            setSelectedPrefectures(defaultPrefectures);
+        }
+    }, [loading, prefectures]);
 
     return (
         <div className={styles.wrapper}>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Prefecture } from '@/apis/types';
 import PrefectureSelector from '@/components/prefecture/PrefectureSelector';
 import PopulationChartContainer from '@/components/chart/PopulationChartContainer';
@@ -12,8 +12,11 @@ export default function AppLayout() {
     const [selectedPrefectures, setSelectedPrefectures] = useState<Prefecture[]>([]);
 
     // 初期選択：東京 (13) と大阪 (27)
+    const didInit = useRef(false);
+
     useEffect(() => {
-        if (!loading && prefectures.length > 0 && selectedPrefectures.length === 0) {
+        if (!loading && prefectures.length > 0 && !didInit.current) {
+            didInit.current = true;
             const defaultPrefectures = prefectures.filter((p) => p.prefCode === 13 || p.prefCode === 27);
             setSelectedPrefectures(defaultPrefectures);
         }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import PrefectureSelector from '../prefecture/PrefectureSelector';
+import { Prefecture } from '@/apis/types';
+import PrefectureSelector from '@/components/prefecture/PrefectureSelector';
+import PopulationChartContainer from '@/components/chart/PopulationChartContainer';
 import styles from '@styles/components/AppLayout.module.scss';
 
 export default function AppLayout() {
-    const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
+    const [selectedPrefectures, setSelectedPrefectures] = useState<Prefecture[]>([]);
 
     return (
         <div className={styles.wrapper}>
@@ -14,7 +16,7 @@ export default function AppLayout() {
             </header>
             <main className={styles.main}>
                 <PrefectureSelector selected={selectedPrefectures} onChange={setSelectedPrefectures} />
-                {/* 🔜 今後ここにチャートを追加予定 */}
+                {selectedPrefectures.length > 0 && <PopulationChartContainer prefectures={selectedPrefectures} />}
             </main>
         </div>
     );

--- a/src/components/prefecture/PrefectureSelector.tsx
+++ b/src/components/prefecture/PrefectureSelector.tsx
@@ -7,8 +7,8 @@ import PrefectureCheckbox from './PrefectureCheckbox';
 import styles from '@styles/components/PrefectureSelector.module.scss';
 
 type Props = {
-    selected: number[];
-    onChange: (selected: number[]) => void;
+    selected: Prefecture[];
+    onChange: (selected: Prefecture[]) => void;
 };
 
 export default function PrefectureSelector({ selected, onChange }: Props) {
@@ -28,7 +28,10 @@ export default function PrefectureSelector({ selected, onChange }: Props) {
     }, []);
 
     const handleChange = (prefCode: number, checked: boolean) => {
-        onChange(checked ? [...selected, prefCode] : selected.filter((code) => code !== prefCode));
+        const prefecture = prefectures.find((p) => p.prefCode === prefCode);
+        if (!prefecture) return;
+
+        onChange(checked ? [...selected, prefecture] : selected.filter((p) => p.prefCode !== prefCode));
     };
 
     return (
@@ -40,7 +43,7 @@ export default function PrefectureSelector({ selected, onChange }: Props) {
                         key={pref.prefCode}
                         prefCode={pref.prefCode}
                         prefName={pref.prefName}
-                        checked={selected.includes(pref.prefCode)}
+                        checked={selected.some((p) => p.prefCode === pref.prefCode)}
                         onChange={handleChange}
                     />
                 ))}

--- a/src/components/prefecture/PrefectureSelector.tsx
+++ b/src/components/prefecture/PrefectureSelector.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { Prefecture } from '@/apis/types';
-import { getPrefectures } from '@/apis/getPrefectures';
+import { usePrefectures } from '@/hooks/usePrefectures';
 import PrefectureCheckbox from './PrefectureCheckbox';
+import Loading from '../common/Loading';
 import styles from '@styles/components/PrefectureSelector.module.scss';
 
 type Props = {
@@ -12,20 +12,7 @@ type Props = {
 };
 
 export default function PrefectureSelector({ selected, onChange }: Props) {
-    const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
-
-    useEffect(() => {
-        const fetchPref = async () => {
-            try {
-                const data = await getPrefectures();
-                setPrefectures(data);
-            } catch (error) {
-                console.error('都道府県の取得に失敗しました', error);
-            }
-        };
-
-        fetchPref();
-    }, []);
+    const { prefectures, loading, error } = usePrefectures();
 
     const handleChange = (prefCode: number, checked: boolean) => {
         const prefecture = prefectures.find((p) => p.prefCode === prefCode);
@@ -37,6 +24,8 @@ export default function PrefectureSelector({ selected, onChange }: Props) {
     return (
         <section className={styles.selector}>
             <h2 className={styles.title}>都道府県を選択</h2>
+            {loading && <Loading />}
+            {error && <p className={styles.error}>{error}</p>}
             <div className={styles.list}>
                 {prefectures.map((pref) => (
                     <PrefectureCheckbox
@@ -47,6 +36,15 @@ export default function PrefectureSelector({ selected, onChange }: Props) {
                         onChange={handleChange}
                     />
                 ))}
+            </div>
+            <div className={styles.actions}>
+                <button
+                    className={styles.unselectButton}
+                    onClick={() => onChange([])}
+                    data-testid="unselect-all-button"
+                >
+                    全ての選択を解除
+                </button>
             </div>
         </section>
     );

--- a/src/hooks/usePopulationData.ts
+++ b/src/hooks/usePopulationData.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getPopulation } from '@/apis/getPopulation';
+import { PopulationDataPoint, PopulationComposition, Prefecture } from '@/apis/types';
+
+// 人口データの取得とラベル選択をまとめたカスタムフック
+export function usePopulationData(prefectures: Prefecture[]) {
+    // 選択中の人口ラベル
+    const [selectedLabel, setSelectedLabel] = useState<PopulationComposition['label']>('総人口');
+    // prefCodeごとの人口データマップ
+    const [chartDataMap, setChartDataMap] = useState<Map<number, PopulationDataPoint[]>>(new Map());
+    // prefCodeごとの都道府県名マップ
+    const [prefNamesMap, setPrefNamesMap] = useState<Map<number, string>>(new Map());
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // データ取得処理
+    useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const promises = prefectures.map(async (pref) => {
+                    const result = await getPopulation(pref.prefCode);
+                    const comp = result.result.data.find((c: PopulationComposition) => c.label === selectedLabel);
+                    return {
+                        prefCode: pref.prefCode,
+                        prefName: pref.prefName,
+                        data: comp?.data || [],
+                    };
+                });
+
+                const results = await Promise.all(promises);
+                const newDataMap = new Map<number, PopulationDataPoint[]>();
+                const newPrefNamesMap = new Map<number, string>();
+
+                results.forEach(({ prefCode, prefName, data }) => {
+                    newDataMap.set(prefCode, data);
+                    newPrefNamesMap.set(prefCode, prefName);
+                });
+
+                setChartDataMap(newDataMap);
+                setPrefNamesMap(newPrefNamesMap);
+            } catch (err) {
+                console.error(err);
+                setError('データ取得に失敗しました');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [prefectures, selectedLabel]);
+
+    return {
+        selectedLabel,
+        setSelectedLabel,
+        chartDataMap,
+        prefNamesMap,
+        loading,
+        error,
+    };
+}

--- a/src/hooks/usePrefectures.ts
+++ b/src/hooks/usePrefectures.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { Prefecture } from '@/apis/types';
+import { getPrefectures } from '@/apis/getPrefectures';
+
+export function usePrefectures() {
+    const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchPref = async () => {
+            try {
+                const data = await getPrefectures();
+                setPrefectures(data);
+            } catch (e) {
+                console.error('都道府県の取得に失敗しました', e);
+                setError('データ取得に失敗しました');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchPref();
+    }, []);
+
+    return { prefectures, loading, error };
+}

--- a/src/styles/GlobalStyles.scss
+++ b/src/styles/GlobalStyles.scss
@@ -56,4 +56,5 @@ body {
     padding: 0;
     background-color: variables.$background-color;
     color: variables.$text-color;
+    overflow-y: scroll;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,2 +1,4 @@
 $text-color: #222222;
+$text-color-light: #e7e7e7;
 $background-color: #fdfdfd;
+$button-color: #007bff;

--- a/src/styles/components/AppLayout.module.scss
+++ b/src/styles/components/AppLayout.module.scss
@@ -23,7 +23,7 @@
     justify-content: flex-start;
     flex: 1;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 2rem;
     padding: 2rem;

--- a/src/styles/components/AppLayout.module.scss
+++ b/src/styles/components/AppLayout.module.scss
@@ -1,18 +1,38 @@
 .wrapper {
     display: flex;
     flex-direction: column;
+    justify-content: flex-start;
     min-height: 100vh;
+    width: 100%;
 }
 
 .header {
-    padding: 10px 20px;
-    font-size: 15px;
+    width: 100%;
+    height: 6rem;
     background-color: #f5f5f5;
     border-bottom: 1px solid #ddd;
-    text-align: center;
+    h1 {
+        text-align: center;
+        font-size: 3.2rem;
+        line-height: 6rem;
+    }
 }
 
 .main {
+    display: flex;
+    justify-content: flex-start;
     flex: 1;
-    padding: 20px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2rem;
+    padding: 2rem;
+}
+
+@media (max-width: 768px) {
+    .header {
+        h1 {
+            font-size: 2.4rem;
+        }
+    }
 }

--- a/src/styles/components/Loading.module.scss
+++ b/src/styles/components/Loading.module.scss
@@ -1,0 +1,28 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    gap: 0.5rem;
+}
+
+.spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #ccc;
+    border-top: 2px solid #007bff;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+.text {
+    font-size: 16px;
+    color: #333;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/styles/components/PopulationChart.module.scss
+++ b/src/styles/components/PopulationChart.module.scss
@@ -1,0 +1,5 @@
+.chart {
+    width: 100%;
+    min-height: 400px;
+    margin-top: 20px;
+}

--- a/src/styles/components/PopulationChartContainer.module.scss
+++ b/src/styles/components/PopulationChartContainer.module.scss
@@ -1,4 +1,6 @@
 .container {
+    width: 100%;
+    max-width: 1000px;
     padding: 1rem;
     background-color: #fff;
     border: 1px solid #ddd;
@@ -8,9 +10,15 @@
 
 .buttonGroup {
     margin-bottom: 1rem;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .button {
+    width: 120px;
     padding: 0.5rem 1rem;
     margin-right: 0.5rem;
     background-color: #e0e0e0;
@@ -19,10 +27,6 @@
     border-radius: 4px;
     cursor: pointer;
     transition: background-color 0.3s;
-}
-
-.button:hover {
-    background-color: #ccc;
 }
 
 .active {

--- a/src/styles/components/PopulationChartContainer.module.scss
+++ b/src/styles/components/PopulationChartContainer.module.scss
@@ -1,0 +1,41 @@
+.container {
+    padding: 1rem;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    margin-top: 1rem;
+}
+
+.buttonGroup {
+    margin-bottom: 1rem;
+}
+
+.button {
+    padding: 0.5rem 1rem;
+    margin-right: 0.5rem;
+    background-color: #e0e0e0;
+    color: #000;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.button:hover {
+    background-color: #ccc;
+}
+
+.active {
+    background-color: #0070f3;
+    color: #fff;
+}
+
+.message {
+    font-size: 1rem;
+    color: #333;
+}
+
+.error {
+    font-size: 1rem;
+    color: red;
+}

--- a/src/styles/components/PrefectureCheckbox.module.scss
+++ b/src/styles/components/PrefectureCheckbox.module.scss
@@ -1,15 +1,17 @@
+@use '../variables';
+
 .checkbox {
+    width: 9.2rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.95rem;
-    padding: 0.3rem 0.5rem;
-    background: #fff;
+    font-size: 1.4rem;
+    padding: 0.5rem;
+    background: variables.$background-color;
     border: 1px solid #ccc;
     border-radius: 4px;
     cursor: pointer;
     user-select: none;
-
     input {
         cursor: pointer;
     }

--- a/src/styles/components/PrefectureSelector.module.scss
+++ b/src/styles/components/PrefectureSelector.module.scss
@@ -1,18 +1,45 @@
+@use '../variables';
+
 .selector {
-    padding: 1.5rem;
+    width: 100%;
+    max-width: 1000px;
     background: #f9f9f9;
     border-radius: 8px;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.05);
 }
 
 .title {
-    font-size: 1.2rem;
+    font-size: 2.4rem;
     font-weight: bold;
     margin-bottom: 1rem;
+    text-align: center;
+    color: variables.$text-color;
 }
 
 .list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(9.2rem, 1fr));
+    gap: 1rem;
+    justify-content: end;
+}
+
+.actions {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    justify-content: center;
+    margin-top: 1.5rem;
+    width: 100%;
+    button {
+        padding: 0.8rem 1.5rem;
+        font-size: 1.6rem;
+        background: variables.$button-color;
+        color: variables.$text-color-light;
+        border: none;
+        border-radius: 0.4rem;
+        cursor: pointer;
+    }
+}
+@media (max-width: 768px) {
+    .title {
+        font-size: 1.8rem;
+    }
 }


### PR DESCRIPTION
## 概要

本PRでは、Yumemiフロントエンドエンジニア・コーディング課題の要件を満たす、都道府県別の人口構成を可視化するアプリケーションを実装しました。

選択された都道府県の人口推移グラフ（総人口・年少人口・生産年齢人口・老年人口）を Highcharts を用いて表示し、
ユーザー体験を高めるためのキャッシュ処理やレスポンシブ対応も含まれています。

---

##  主な機能・実装内容

### API連携
- `/prefectures` → 都道府県一覧を取得（キャッシュ付き）
- `/population/composition/perYear?prefCode=X` → 人口構成データ取得（prefCodeごとにキャッシュ）

###  UIコンポーネント
- `PrefectureSelector`: チェックボックス式都道府県選択 UI（Unselect All 機能付き）
- `PopulationChartContainer`: 人口種別切り替えボタン（単一選択）
- `PopulationChart`: Highcharts で描画された人口推移グラフ
- `Loading`: 読み込み用のスピナー付きローディング表示（共通UI）

### ロジック/UX
- 初回は東京（13）と大阪（27）を自動選択
- API取得時のキャッシュ保存と参照によるパフォーマンス向上
- ラベル切り替え時に再フェッチせず、キャッシュから即座に切替
- エラーハンドリングとユーザー向けメッセージ表示

###  レスポンシブ対応
- チェックボックス・ボタンUIなど主要部分をモバイルサイズに最適化
- グラフのフォントサイズを画面幅に応じて動的に調整

###  テスト
- `getPrefectures`, `getPopulation` など API 層のユニットテスト
- `usePopulationData`, `usePrefectures` フックのロジックテスト
- `PopulationChart`, `PrefectureSelector` など UIコンポーネントのテスト
- `Loading` コンポーネント単体の表示検証テスト

---

## 技術スタック・方針

| 項目 | 内容 |
|------|------|
| フレームワーク | Next.js 15 (App Router) |
| 言語 | TypeScript |
| グラフ描画 | Highcharts |
| スタイル | SCSS Modules（レスポンシブ対応済み） |
| テスト | Jest + React Testing Library |
| 状態管理 | React Hooks（useState, useEffect, useRef） |
| API層 | Axios + 型定義分離（`apis/` に集約） |
| フック構成 | `usePrefectures`, `usePopulationData` で fetch ロジックを分離 |
| CI/CD | GitHub Actions によるテスト実行、Vercel への自動デプロイ |
